### PR TITLE
Fixed height of logger view.

### DIFF
--- a/tailon/assets/js/main.js
+++ b/tailon/assets/js/main.js
@@ -49,7 +49,7 @@ function isInputFocused() {
 }
 
 function resizeLogview() {
-  var toolbarHeight = (uimodel.get('pannel-hidden') ? 0 : $('.toolbar').height()); // todo
+  var toolbarHeight = (uimodel.get('pannel-hidden') ? 0 : $('.toolbar').outerHeight(true)); // todo
   logviewer.container.height(window.innerHeight - toolbarHeight);
 }
 


### PR DESCRIPTION
The height of the logger view is incorrect. It cuts of the last line (see attached image). This is due to the toolbar having a margin that is not included in the calculations when sizing the logger view.

This PR fixes that.

![logger-height-incorrect](https://cloud.githubusercontent.com/assets/487039/5514989/45c66be2-8855-11e4-878c-6ee62ad06ad7.png)
