### PR TITLE
Force grep to process files as text.

### DIFF
--- a/tailon/server.py
+++ b/tailon/server.py
@@ -39,7 +39,7 @@ class Commands:
         return p
 
     def grep(self, regex, fn, stdout, stderr, **kw):
-        cmd = [self.grepexe, '--line-buffered', '--color=never', '-e', regex]
+        cmd = [self.grepexe, '--text', '--line-buffered', '--color=never', '-e', regex]
         if fn:
             cmd.append(fn)
         p = Subprocess(cmd, stdout=stdout, stderr=stderr, **kw)


### PR DESCRIPTION
Fixes message "Binary file (standard input) matches" when log file contains NUL character.

This PR properly shows matching lines regardless of NUL character present in log files.
