### PR TITLE
Improved display of file size in dropdown.

### DIFF
--- a/tailon/assets/css/main.css
+++ b/tailon/assets/css/main.css
@@ -224,6 +224,19 @@ body {
       background: #373b41;
       border-left: 0; }
 
+.select2-results .select2-filename-wrap {
+  display: table;
+  width: 100%;
+}
+  .select2-results .select2-filename-size {
+    display: table-cell;
+    text-align: right;
+  }
+  .select2-results .select2-filename-text {
+    display: table-cell;
+    padding-right: 20px;
+  }
+
 /* log view style */
 .scrollable {
   overflow-y: auto; }

--- a/tailon/assets/js/main.js
+++ b/tailon/assets/js/main.js
@@ -22,7 +22,7 @@ function formatBytes(size) {
 function formatFilename(state) {
   if (!state.id) return state.text;
   var size = formatBytes($(state.element).data('size'));
-  return '<span>'+state.text+'</span>' + '<span style="float:right;">'+size+'</span>';
+  return '<div class="select2-filename-wrap"><div class="select2-filename-text">' + state.text + '</div><div class="select2-filename-size">' + size + '</div></div>';
 }
 
 function endsWith(str, suffix) {


### PR DESCRIPTION
The size of the files in the dropdown are sometimes dropped to a second row due to lack of space. See attached image.

![select-option-bad](https://cloud.githubusercontent.com/assets/487039/5518013/d8980038-890f-11e4-8ef6-dd00ae65788c.png)

This PR improves on this making sure that each filename and filesize are on the same line.

![select-option-good](https://cloud.githubusercontent.com/assets/487039/5518014/e600d088-890f-11e4-839d-6d4c1200f754.png)

I tried to adhere to the coding style in the project. I'll be glad to fix any incorrect formatting or naming convention if wanted.
