### PR TITLE
Support enabling debugging from the configuration file

### DIFF
--- a/tailon/main.py
+++ b/tailon/main.py
@@ -263,10 +263,10 @@ def main(argv=sys.argv):
         print('\n%s' % msg, file=sys.stderr)
         sys.exit(1)
 
-    if opts.debug:
-        enable_debugging()
-
     config = setup(opts)
+
+    if config['debug']:
+        enable_debugging()
 
     file_utils = utils.FileUtils(use_directory_cache=True)
     file_lister = utils.FileLister(file_utils, config['files'], config['follow-names'])


### PR DESCRIPTION
Move the check for the debugging option to after the configuration
file has been parsed. This means that it will be enabled if either the
--debug flag is passed, or the debug key in the configuration file is
present.

Previously, debugging would only be enabled when the --debug flag is
passed.