### PR TITLE
Feature: Add ability to include extra files definitions

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,7 @@ relative-root: /tailon  # web app root path (default: '')
 commands: [tail, grep]  # allowed commands
 tail-lines: 10          # number of lines to tail initially
 wrap-lines: true        # initial line-wrapping state
+extra-files-dir: /etc/tailon/files.d/
 
 files:
   - '/var/log/messages'

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ classifiers = [
 ]
 
 requirements = [
+    'deepmerger',
     'tornado>=4.0.0,<5.0.0',
     'tornado-http-auth>=1.0.0',
     'sockjs-tornado>=1.0.0',


### PR DESCRIPTION
This add an ability to append to the `files` entries in the main configuration file, using additional config options from a `files.d` type directory.

A new application, could create a new file in `/etc/tailon/files.d/myapp.yml` with
```
files:
- '/opt/myapp/logs/'
- 'cron':
    - '/opt/myapp/cron-logs/'
```
And those paths would be included into the file paths.

This is trying to solve scenarios where tailon is deployed across a fleet of systems but some systems need to include additional source file locations for specific app purpose and not need to recreate or worry about the existing config defining `bind` port or `allow-transfers`.