### PR TITLE
Update commands.py

### DIFF
--- a/tailon/commands.py
+++ b/tailon/commands.py
@@ -47,7 +47,7 @@ class CommandControl:
         return proc
 
     def grep(self, regex, fn, stdout, stderr, **kw):
-        cmd = [self.toolpaths.cmd_grep, '--text', '--line-buffered', '--color=never', '-e', regex]
+        cmd = [self.toolpaths.cmd_grep, '--text', '--line-buffered', '--color=never', '-E', regex]
         if fn:
             cmd.append(fn)
         proc = process.Subprocess(cmd, stdout=stdout, stderr=stderr, **kw)


### PR DESCRIPTION
if you change the grep option -e with -E you can use more advanced regexp like  (foo|bar) or foo.*bar to inlcude just lines that contains foo OR bar strings or, in the second case, foo AND bar useful in very big syslog files ;).
It will be nice to have an help page with some examples like those, and the possibility to save some searches