### PR TITLE
Corrected typo in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ classifiers = [
 ]
 
 requirements = [
-    'deepmerger',
+    'deepmerge',
     'tornado>=4.0.0,<5.0.0',
     'tornado-http-auth>=1.0.0',
     'sockjs-tornado>=1.0.0',


### PR DESCRIPTION
This typo prevents installation.  Introduced in PR 50: https://github.com/gvalkov/tailon/pull/50/files#diff-2eeaed663bd0d25b7e608891384b7298R13

```
stderr:   Could not find a version that satisfies the requirement deepmerger (from tailon) (from versions: )
No matching distribution found for deepmerger (from tailon)
```

```
$ pip search deepmerger
$ pip search deepmerge
deepmerge (0.0.4)  - a toolset to deeply merge python dictionaries.
```