### PR TITLE
deprecated yaml method

### DIFF
--- a/tailon/main.py
+++ b/tailon/main.py
@@ -58,7 +58,7 @@ def enable_debugging():
 def parseconfig(cfg):
     import yaml
 
-    raw_config = yaml.load(cfg)
+    raw_config = yaml.safe_load(cfg)
 
     port, addr = utils.parseaddr(raw_config.get('bind', 'localhost:8080'))
     config = {


### PR DESCRIPTION
solving  error
.local/lib/python3.9/site-packages/tailon/main.py", line 61, in parseconfig
    raw_config = yaml.load(cfg)
TypeError: load() missing 1 required positional argument: 'Loader'