### PR TITLE
depracet yaml.load method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     'tornado>=4.0.0,<5.0.0',
     'tornado-http-auth>=1.0.0',
     'sockjs-tornado>=1.0.0',
-    'PyYAML>=3.11',
+    'PyYAML>=6.0',
 ]
 
 kw = {


### PR DESCRIPTION
https://bobbyhadz.com/blog/python-typeerror-load-missing-1-required-positional-argument-loader

.local/lib/python3.9/site-packages/tailon/main.py", line 61, in parseconfig
    raw_config = yaml.load(cfg)
TypeError: load() missing 1 required positional argument: 'Loader'